### PR TITLE
Update node.js.yml for better ci/cd

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -48,16 +48,18 @@ jobs:
     - run: npm run build
     - run: npm test
 
-    - name: Setup Pages
+    - if: ${{ github.repository == 'KEA-ACCELER/about' && github.event_name != 'pull_request' }}
+      name: Setup Pages
       uses: actions/configure-pages@v3
 
-    - name: Upload pages artifact
+    - if: ${{ github.repository == 'KEA-ACCELER/about' && github.event_name != 'pull_request' }}
+      name: Upload pages artifact
       uses: actions/upload-pages-artifact@v1
       with:
         path: ./build
 
   deploy:
-    if: github.repository == 'KEA-ACCELER/about'
+    if: ${{ github.repository == 'KEA-ACCELER/about' && github.event_name != 'pull_request' }}
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -39,23 +39,17 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Use Node.js ${{ matrix.node-version }}
+    - name: Setup Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
+    - run: npm ci
+    - run: npm run build
+    - run: npm test
 
     - name: Setup Pages
       uses: actions/configure-pages@v3
-
-    - name: Install modules
-      run: npm ci
-
-    - name: Run build
-      run: npm run build
-
-    - name: Run test
-      run: npm test
 
     - name: Upload pages artifact
       uses: actions/upload-pages-artifact@v1
@@ -63,6 +57,7 @@ jobs:
         path: ./build
 
   deploy:
+    if: github.repository == 'KEA-ACCELER/about'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
Update node.js.yml for better ci/cd
Now, node.js dependencies are cached and used.
If not merged into main, the deploy job will not run.